### PR TITLE
Optional React imports for compatibility

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import './App.css';
 import Main from './pages/Main';
 import Navbar from './Navbar';

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Main from "./pages/Main";
 import Reservation from "./pages/Reservation";
 import Status from "./pages/Status";

--- a/src/pages/Gallery.js
+++ b/src/pages/Gallery.js
@@ -1,3 +1,4 @@
+import React from 'react';
 function Gallery() {
   function GalleryCarousel() {
     return (

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,3 +1,4 @@
+import React from 'react';
 function Main() {
     return (
       <>

--- a/src/pages/Reservation.js
+++ b/src/pages/Reservation.js
@@ -1,3 +1,4 @@
+import React from 'react';
 function Reservation() {
     return (
       <>

--- a/src/pages/Status.js
+++ b/src/pages/Status.js
@@ -1,3 +1,4 @@
+import React from 'react';
 function Status() {
     return (
       <>


### PR DESCRIPTION
Latest React should not require importing React libraries to each of its' .JS/.JSX files but for compatibility of different app builders I added those imports. It makes possible to run my project on web IDE platforms supporting NodeJS like StackBlitz.